### PR TITLE
ON-484: fix equip mixed gloves edge case

### DIFF
--- a/contracts/Aavegotchi/facets/AavegotchiFacet.sol
+++ b/contracts/Aavegotchi/facets/AavegotchiFacet.sol
@@ -137,7 +137,7 @@ contract AavegotchiFacet is Modifiers {
     }
 
     function _enforceAavegotchiNotEquippedWithDelegatedItems(uint256 _tokenId) internal view {
-        require(s.gotchiEquippedItemsInfo[_tokenId].equippedDelegateItemsCount == 0, "AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
+        require(s.gotchiEquippedItemsInfo[_tokenId].equippedDelegatedItemsCount == 0, "AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
     }
 
     /// @notice Transfers the ownership of an NFT from one address to another address

--- a/contracts/Aavegotchi/facets/ItemsFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsFacet.sol
@@ -228,7 +228,10 @@ contract ItemsFacet is Modifiers {
         Aavegotchi storage aavegotchi = s.aavegotchis[_tokenId];
         require(aavegotchi.status == LibAavegotchi.STATUS_AAVEGOTCHI, "LibAavegotchi: Only valid for AG");
 
-        for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
+        bool _sameHands =_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_LEFT] == _wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_RIGHT];
+        bool _sameDeposits = _depositIds[LibItems.WEARABLE_SLOT_HAND_LEFT].nonce == _depositIds[LibItems.WEARABLE_SLOT_HAND_RIGHT].nonce;
+       
+       for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
             uint256 toEquipId = _wearablesToEquip[slot];
             uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
 
@@ -273,16 +276,9 @@ contract ItemsFacet is Modifiers {
                 //Then check if this wearable is in the Aavegotchis inventory
                 uint256 nftBalance = s.nftItemBalances[address(this)][_tokenId][toEquipId];
                 uint256 neededBalance = 1;
-                if (slot == LibItems.WEARABLE_SLOT_HAND_LEFT) {
-                    if (_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_RIGHT] == toEquipId) {
-                        neededBalance = 2;
-                    }
-                }
 
-                if (slot == LibItems.WEARABLE_SLOT_HAND_RIGHT) {
-                    if (_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_LEFT] == toEquipId) {
-                        neededBalance = 2;
-                    }
+                if(slot == LibItems.WEARABLE_SLOT_HAND_LEFT && _sameHands && _sameDeposits || slot == LibItems.WEARABLE_SLOT_HAND_RIGHT && _sameHands && !_sameDeposits) {
+                    neededBalance = 2;
                 }
 
                 if (nftBalance < neededBalance) {

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -221,20 +221,15 @@ struct ERC721BuyOrder {
     bool[] validationOptions;
 }
 
-struct EquippedDelegatedItemInfo {
-    ItemDepositId depositId;
-    uint256 balance;
-}
-
 struct ItemDepositId {
     uint256 nonce;
     address grantor;
 }
 
 struct GotchiEquippedItemsInfo {
-    // wearableTokenId => equippedItemIdToDelegationInfo
-    mapping(uint256 => EquippedDelegatedItemInfo) equippedItemIdToDelegationInfo;
-    uint256 equippedDelegateItemsCount;
+    // slotPosition => depositId
+    mapping(uint256 => ItemDepositId) equippedDelegatedItems;
+    uint256 equippedDelegatedItemsCount;
 }
 
 struct AppStorage {

--- a/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
+++ b/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
@@ -782,6 +782,154 @@ describe("ItemsRolesRegistryFacet", async () => {
         .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[3], 1)
         .to.not.emit(libEventHandler, "TransferSingle");
     })
+    it("should equip and unequip two gloves one not and one delegated", async () => {
+      await wearablesFacet
+        .connect(grantor)
+        .safeTransferFrom(
+          grantor.address,
+          LargeGotchiOwner,
+          wearableIds[0],
+          1,
+          "0x"
+        );
+
+      const granteeAddress = await grantee.getAddress();
+      const newRoleAssignment1 = await buildRoleAssignment({
+        tokenAddress: wearablesFacet.address,
+        tokenId: wearableIds[0],
+        grantor: grantor.address,
+        grantee: granteeAddress,
+        tokenAmount: 1,
+      });
+
+      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+        newRoleAssignment1
+      )
+
+      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+        nonce: 0,
+        grantor: AddressZero,
+      });
+
+      itemDepositIds[4] = {
+        nonce: newRoleAssignment1.nonce,
+        grantor: newRoleAssignment1.grantor,
+      };
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            itemDepositIds
+          )
+      )
+        .to.emit(libERC1155, "TransferToParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+        .to.emit(libEventHandler, "TransferSingle")
+        .withArgs(
+          granteeAddress,
+          granteeAddress,
+          aavegotchiDiamondAddress,
+          wearableIds[0],
+          1
+        )
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            emptyWearableIds,
+            emptyItemDepositIds
+          )
+      ).to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+        .to.emit(libERC1155, "TransferFromParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+    })
+    it('should equip and unequp two gloves one delegated one not', async () => {
+      await wearablesFacet
+        .connect(grantor)
+        .safeTransferFrom(
+          grantor.address,
+          LargeGotchiOwner,
+          wearableIds[0],
+          1,
+          "0x"
+        );
+
+      const granteeAddress = await grantee.getAddress();
+      const newRoleAssignment1 = await buildRoleAssignment({
+        tokenAddress: wearablesFacet.address,
+        tokenId: wearableIds[0],
+        grantor: grantor.address,
+        grantee: granteeAddress,
+        tokenAmount: 1,
+      });
+
+      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+        newRoleAssignment1
+      )
+
+      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+        nonce: 0,
+        grantor: AddressZero,
+      });
+
+      itemDepositIds[5] = {
+        nonce: newRoleAssignment1.nonce,
+        grantor: newRoleAssignment1.grantor,
+      };
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            itemDepositIds
+          )
+      )
+        .to.emit(libERC1155, "TransferToParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+        .to.emit(libEventHandler, "TransferSingle")
+        .withArgs(
+          granteeAddress,
+          granteeAddress,
+          aavegotchiDiamondAddress,
+          wearableIds[0],
+          1
+        )
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            emptyWearableIds,
+            emptyItemDepositIds
+          )
+      ).to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+        .to.emit(libERC1155, "TransferFromParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+    })
     it('should NOT transfer an aavegotchi with mixed wearables equipped', async () => {
       await wearablesFacet
         .connect(grantor)


### PR DESCRIPTION
Edge case 1: 
- Consider a glove id 17
- Consider an grantee has only 1 tokenAmount of glove 17, 
- Consider that the grantee receive a delegation of 1 tokenAmount for glove 17

1. grantee tries to equip both gloves in his gotchi
2. `equipWearables` function will notice that he is equipping both gloves with same id. It will require a needBalance of 2
3. Since grantee doesn't have that balance, transaction will revert

Edge case 2: 
- Consider a glove id 17 
- Consider that the grantee receive a delegation of 1 tokenAmount for glove 17 from grantor1 - delegation 1
- Consider that the grantee receive a delegation of 1 tokenAmount for glove 17 from grantor2 - delegation 2

1. grantee tries to equip both gloves in his gotchi
2. `equipWearables` function will notice that he is equipping both gloves with same id. It will require a needBalance of 2 for delegation1
3. Since delegation1 doesn't have that balance, transaction will revert

With that fix, now the `equipWearables` function will check besides having two gloves with the same id, if it also has the same deposit id.