### PR TITLE
ON-584: equip wearables edge cases

### DIFF
--- a/contracts/Aavegotchi/facets/AavegotchiFacet.sol
+++ b/contracts/Aavegotchi/facets/AavegotchiFacet.sol
@@ -137,7 +137,7 @@ contract AavegotchiFacet is Modifiers {
     }
 
     function _enforceAavegotchiNotEquippedWithDelegatedItems(uint256 _tokenId) internal view {
-        require(s.gotchiEquippedItemsInfo[_tokenId].equippedDelegateItemsCount == 0, "AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
+        require(s.gotchiEquippedItemsInfo[_tokenId].equippedDelegatedItemsCount == 0, "AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
     }
 
     /// @notice Transfers the ownership of an NFT from one address to another address

--- a/contracts/Aavegotchi/facets/ItemsFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsFacet.sol
@@ -228,7 +228,10 @@ contract ItemsFacet is Modifiers {
         Aavegotchi storage aavegotchi = s.aavegotchis[_tokenId];
         require(aavegotchi.status == LibAavegotchi.STATUS_AAVEGOTCHI, "LibAavegotchi: Only valid for AG");
 
-        for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
+        bool _sameHands =_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_LEFT] == _wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_RIGHT];
+        bool _sameDeposits = _depositIds[LibItems.WEARABLE_SLOT_HAND_LEFT].nonce == _depositIds[LibItems.WEARABLE_SLOT_HAND_RIGHT].nonce;
+       
+       for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
             uint256 toEquipId = _wearablesToEquip[slot];
             uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
 
@@ -273,16 +276,9 @@ contract ItemsFacet is Modifiers {
                 //Then check if this wearable is in the Aavegotchis inventory
                 uint256 nftBalance = s.nftItemBalances[address(this)][_tokenId][toEquipId];
                 uint256 neededBalance = 1;
-                if (slot == LibItems.WEARABLE_SLOT_HAND_LEFT) {
-                    if (_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_RIGHT] == toEquipId) {
-                        neededBalance = 2;
-                    }
-                }
 
-                if (slot == LibItems.WEARABLE_SLOT_HAND_RIGHT) {
-                    if (_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_LEFT] == toEquipId) {
-                        neededBalance = 2;
-                    }
+                if(slot == LibItems.WEARABLE_SLOT_HAND_LEFT && _sameHands && _sameDeposits || slot == LibItems.WEARABLE_SLOT_HAND_RIGHT && _sameHands && !_sameDeposits) {
+                    neededBalance = 2;
                 }
 
                 if (nftBalance < neededBalance) {

--- a/contracts/Aavegotchi/facets/ItemsFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsFacet.sol
@@ -219,7 +219,7 @@ contract ItemsFacet is Modifiers {
     function _equipWearables(
         uint256 _tokenId,
         uint16[EQUIPPED_WEARABLE_SLOTS] calldata _wearablesToEquip,
-        ItemDepositId[EQUIPPED_WEARABLE_SLOTS] memory _depositsIdToEquip
+        ItemDepositId[EQUIPPED_WEARABLE_SLOTS] memory _depositIdsToEquip
     )
         internal
         onlyAavegotchiOwner(_tokenId)
@@ -235,7 +235,7 @@ contract ItemsFacet is Modifiers {
             uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
             bool _sameWearablesIds = toEquipId == existingEquippedWearableId;
 
-            ItemDepositId memory _depositIdToEquip = _depositsIdToEquip[slot];
+            ItemDepositId memory _depositIdToEquip = _depositIdsToEquip[slot];
             ItemDepositId storage _existingEquippedDepositId = _gotchiInfo.equippedDelegatedItems[slot];
 
             //If the new wearable value is equal to the current equipped wearable in that slot

--- a/contracts/Aavegotchi/facets/ItemsFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsFacet.sol
@@ -230,12 +230,14 @@ contract ItemsFacet is Modifiers {
         GotchiEquippedItemsInfo storage _gotchiInfo = s.gotchiEquippedItemsInfo[_tokenId];
 
         for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
-                
-            uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
+            
             uint256 toEquipId = _wearablesToEquip[slot];
-            ItemDepositId memory _depositIdToEquip = _depositsIdToEquip[slot];
-            ItemDepositId storage _existingEquippedDepositId = s.gotchiEquippedItemsInfo[_tokenId].equippedDelegatedItems[slot];
+            uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
             bool _sameWearablesIds = toEquipId == existingEquippedWearableId;
+
+            ItemDepositId memory _depositIdToEquip = _depositsIdToEquip[slot];
+            ItemDepositId storage _existingEquippedDepositId = _gotchiInfo.equippedDelegatedItems[slot];
+
             //If the new wearable value is equal to the current equipped wearable in that slot
             //do nothing
             if (_sameWearablesIds
@@ -312,7 +314,7 @@ contract ItemsFacet is Modifiers {
             IEventHandlerFacet(s.wearableDiamond).emitTransferSingleEvent(_sender, _sender, address(this), _toEquipWearableId, 1);
             LibERC1155Marketplace.updateERC1155Listing(address(this), _toEquipWearableId, _sender);
         }
-       
+
         LibItems.addToParent(address(this), _gotchiId, _toEquipWearableId, 1);
         emit LibERC1155.TransferToParent(address(this), _gotchiId, _toEquipWearableId, 1);
     }

--- a/contracts/Aavegotchi/facets/ItemsFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsFacet.sol
@@ -219,7 +219,7 @@ contract ItemsFacet is Modifiers {
     function _equipWearables(
         uint256 _tokenId,
         uint16[EQUIPPED_WEARABLE_SLOTS] calldata _wearablesToEquip,
-        ItemDepositId[EQUIPPED_WEARABLE_SLOTS] memory _depositIds
+        ItemDepositId[EQUIPPED_WEARABLE_SLOTS] memory _depositIdToEquip
     )
         internal
         onlyAavegotchiOwner(_tokenId)
@@ -228,120 +228,96 @@ contract ItemsFacet is Modifiers {
         Aavegotchi storage aavegotchi = s.aavegotchis[_tokenId];
         require(aavegotchi.status == LibAavegotchi.STATUS_AAVEGOTCHI, "LibAavegotchi: Only valid for AG");
 
-        bool _sameHands =_wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_LEFT] == _wearablesToEquip[LibItems.WEARABLE_SLOT_HAND_RIGHT];
-        bool _sameDeposits = _depositIds[LibItems.WEARABLE_SLOT_HAND_LEFT].nonce == _depositIds[LibItems.WEARABLE_SLOT_HAND_RIGHT].nonce;
-        
         for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
-            _equipOrUnequip(_tokenId, _depositIds[slot], _wearablesToEquip[slot], slot, _sameHands, _sameDeposits);
+                
+            uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
+            uint256 toEquipId = _wearablesToEquip[slot];
+            ItemDepositId storage _existingEquippedDepositId = s.gotchiEquippedItemsInfo[_tokenId].equippedDelegatedItems[slot];
+
+            //If the new wearable value is equal to the current equipped wearable in that slot
+            //do nothing
+            if (toEquipId == existingEquippedWearableId 
+                && _existingEquippedDepositId.nonce == _depositIdToEquip[slot].nonce 
+                && _existingEquippedDepositId.grantor == _depositIdToEquip[slot].grantor) {
+                continue;
+            }
+
+            //Equips new wearable (or sets to 0)
+            aavegotchi.equippedWearables[slot] = uint16(toEquipId);
+
+            //If a wearable was equipped in this slot and can be transferred, transfer back to owner.
+
+            if (existingEquippedWearableId != 0 && s.itemTypes[existingEquippedWearableId].canBeTransferred) {
+                // remove wearable from Aavegotchi and transfer item to owner
+                _removeWearableFromGotchi(_tokenId, existingEquippedWearableId, slot);
+            }
+
+            //If a wearable is being equipped
+            if (toEquipId != 0) {
+                ItemType storage itemType = s.itemTypes[toEquipId];
+                require(LibAavegotchi.aavegotchiLevel(aavegotchi.experience) >= itemType.minLevel, "ItemsFacet: AG level lower than minLevel");
+                require(itemType.category == LibItems.ITEM_CATEGORY_WEARABLE, "ItemsFacet: Only wearables can be equippped");
+                require(itemType.slotPositions[slot] == true, "ItemsFacet: Wearable can't be equipped in slot");
+                {
+                    bool canBeEquipped;
+                    uint8[] memory allowedCollaterals = itemType.allowedCollaterals;
+                    if (allowedCollaterals.length > 0) {
+                        uint256 collateralIndex = s.collateralTypeIndexes[aavegotchi.collateralType];
+
+                        for (uint256 i; i < allowedCollaterals.length; i++) {
+                            if (collateralIndex == allowedCollaterals[i]) {
+                                canBeEquipped = true;
+                                break;
+                            }
+                        }
+                        require(canBeEquipped, "ItemsFacet: Wearable can't be used for this collateral");
+                    }
+                }
+
+                //Transfer to Aavegotchi
+                _addWearableToGotchi(_depositIdToEquip[slot], _tokenId, toEquipId, slot);
+            }
         }
         LibAavegotchi.interact(_tokenId);
-    }
-
-    function _equipOrUnequip(
-        uint256 _tokenId,
-        ItemDepositId memory _depositId,
-        uint256 toEquipId,
-        uint256 slot,
-        bool _sameHands,
-        bool _sameDeposits
-    ) internal {
-        GotchiEquippedItemsInfo storage _gotchiInfo = s.gotchiEquippedItemsInfo[_tokenId];
-        Aavegotchi storage aavegotchi = s.aavegotchis[_tokenId];
-        uint256 existingEquippedWearableId = aavegotchi.equippedWearables[slot];
-
-        //If the new wearable value is equal to the current equipped wearable in that slot
-        //do nothing
-        if (toEquipId == existingEquippedWearableId 
-            && _gotchiInfo.equippedDelegatedItems[slot].nonce == _depositId.nonce 
-            && _gotchiInfo.equippedDelegatedItems[slot].grantor == _depositId.grantor) {
-            return;
-        }
-
-        //Equips new wearable (or sets to 0)
-        aavegotchi.equippedWearables[slot] = uint16(toEquipId);
-
-        //If a wearable was equipped in this slot and can be transferred, transfer back to owner.
-
-        if (existingEquippedWearableId != 0 && s.itemTypes[existingEquippedWearableId].canBeTransferred) {
-            // remove wearable from Aavegotchi and transfer item to owner
-            _removeWearableFromGotchi(_tokenId, existingEquippedWearableId, slot, _gotchiInfo);
-        }
-
-        //If a wearable is being equipped
-        if (toEquipId != 0) {
-            ItemType storage itemType = s.itemTypes[toEquipId];
-            require(LibAavegotchi.aavegotchiLevel(aavegotchi.experience) >= itemType.minLevel, "ItemsFacet: AG level lower than minLevel");
-            require(itemType.category == LibItems.ITEM_CATEGORY_WEARABLE, "ItemsFacet: Only wearables can be equippped");
-            require(itemType.slotPositions[slot] == true, "ItemsFacet: Wearable can't be equipped in slot");
-            {
-                bool canBeEquipped;
-                uint8[] memory allowedCollaterals = itemType.allowedCollaterals;
-                if (allowedCollaterals.length > 0) {
-                    uint256 collateralIndex = s.collateralTypeIndexes[aavegotchi.collateralType];
-
-                    for (uint256 i; i < allowedCollaterals.length; i++) {
-                        if (collateralIndex == allowedCollaterals[i]) {
-                            canBeEquipped = true;
-                            break;
-                        }
-                    }
-                    require(canBeEquipped, "ItemsFacet: Wearable can't be used for this collateral");
-                }
-            }
-
-            //Then check if this wearable is in the Aavegotchis inventory
-            uint256 nftBalance = s.nftItemBalances[address(this)][_tokenId][toEquipId];
-            uint256 neededBalance = 1;
-
-            if(slot == LibItems.WEARABLE_SLOT_HAND_LEFT && _sameHands && _sameDeposits || slot == LibItems.WEARABLE_SLOT_HAND_RIGHT && _sameHands && !_sameDeposits) {
-                neededBalance = 2;
-            }
-
-            if (nftBalance < neededBalance) {
-                //Transfer to Aavegotchi
-                _addWearableToGotchi(_depositId, _tokenId, toEquipId, neededBalance - nftBalance, slot, _gotchiInfo);
-            }
-        }
     }
 
     function _addWearableToGotchi(
         ItemDepositId memory _depositId,
         uint256 _gotchiId,
         uint256 _toEquipWearableId,
-        uint256 _balToTransfer,
-        uint256 _slot,
-        GotchiEquippedItemsInfo storage _gotchiInfo
+        uint256 _slot
     ) internal {
+        GotchiEquippedItemsInfo storage _gotchiInfo = s.gotchiEquippedItemsInfo[_gotchiId];
         address _sender = LibMeta.msgSender();
         
         if (_depositId.nonce != 0) {
             require(s.itemsRoleAssignments[_depositId.grantor][_depositId.nonce].grantee == _sender, "ItemsFacet: Wearable not delegated to sender or depositId not valid");
             require(s.itemsDeposits[_depositId.grantor][_depositId.nonce].tokenId == _toEquipWearableId, "ItemsFacet: Delegated Wearable not of this delegation");
-            require(s.itemsDepositsUnequippedBalance[_depositId.grantor][_depositId.nonce] >= _balToTransfer, "ItemsFacet: Not enough delegated balance");
+            require(s.itemsDepositsUnequippedBalance[_depositId.grantor][_depositId.nonce] >= 1, "ItemsFacet: Not enough delegated balance");
             require(s.itemsRoleAssignments[_depositId.grantor][_depositId.nonce].expirationDate > block.timestamp, "ItemsFacet: Wearable delegation expired");
             
             _gotchiInfo.equippedDelegatedItems[_slot] = _depositId;
-            s.itemsDepositsUnequippedBalance[_depositId.grantor][_depositId.nonce] -= _balToTransfer;
-            _gotchiInfo.equippedDelegatedItemsCount += _balToTransfer;
+            s.itemsDepositsUnequippedBalance[_depositId.grantor][_depositId.nonce] -= 1;
+            _gotchiInfo.equippedDelegatedItemsCount += 1;
             s.depositIdToEquippedGotchis[_depositId.grantor][_depositId.nonce].add(_gotchiId);
         } else {
-            require(s.ownerItemBalances[_sender][_toEquipWearableId] >= _balToTransfer, "ItemsFacet: Wearable isn't in inventory");
+            require(s.ownerItemBalances[_sender][_toEquipWearableId] >= 1, "ItemsFacet: Wearable isn't in inventory");
 
-            LibItems.removeFromOwner(_sender, _toEquipWearableId, _balToTransfer);
-            IEventHandlerFacet(s.wearableDiamond).emitTransferSingleEvent(_sender, _sender, address(this), _toEquipWearableId, _balToTransfer);
+            LibItems.removeFromOwner(_sender, _toEquipWearableId, 1);
+            IEventHandlerFacet(s.wearableDiamond).emitTransferSingleEvent(_sender, _sender, address(this), _toEquipWearableId, 1);
             LibERC1155Marketplace.updateERC1155Listing(address(this), _toEquipWearableId, _sender);
         }
 
-        LibItems.addToParent(address(this), _gotchiId, _toEquipWearableId, _balToTransfer);
-        emit LibERC1155.TransferToParent(address(this), _gotchiId, _toEquipWearableId, _balToTransfer);
+        LibItems.addToParent(address(this), _gotchiId, _toEquipWearableId, 1);
+        emit LibERC1155.TransferToParent(address(this), _gotchiId, _toEquipWearableId, 1);
     }
     
     function _removeWearableFromGotchi(
         uint256 _gotchiId,
         uint256 _existingEquippedWearableId,
-        uint256 _slot,
-        GotchiEquippedItemsInfo storage _gotchiInfo
+        uint256 _slot
     ) internal {
+        GotchiEquippedItemsInfo storage _gotchiInfo = s.gotchiEquippedItemsInfo[_gotchiId];
         address _sender = LibMeta.msgSender();
 
         LibItems.removeFromParent(address(this), _gotchiId, _existingEquippedWearableId, 1);

--- a/contracts/Aavegotchi/facets/ItemsRolesRegistryFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsRolesRegistryFacet.sol
@@ -9,7 +9,7 @@ import {LibItems} from "../libraries/LibItems.sol";
 import {LibMeta} from "../../shared/libraries/LibMeta.sol";
 import {LibERC1155Marketplace} from "../libraries/LibERC1155Marketplace.sol";
 
-import {Modifiers, ItemType, EQUIPPED_WEARABLE_SLOTS, GotchiEquippedItemsInfo} from "../libraries/LibAppStorage.sol";
+import {Modifiers, ItemType, EQUIPPED_WEARABLE_SLOTS, GotchiEquippedItemsInfo, Aavegotchi} from "../libraries/LibAppStorage.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import {ERC1155Holder, ERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import {IEventHandlerFacet} from "../WearableDiamond/interfaces/IEventHandlerFacet.sol";
@@ -217,17 +217,18 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
 
     function _unequipDelegatedWearable(uint256 _gotchiId, uint256 _tokenIdToUnequip, address _grantor, uint256 _nonce) internal {
         GotchiEquippedItemsInfo storage _gotchiInfo = s.gotchiEquippedItemsInfo[_gotchiId];
-
+        Aavegotchi storage _aavegotchi = s.aavegotchis[_gotchiId];
         uint256 _unequippedBalance;
         for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
-            if (s.aavegotchis[_gotchiId].equippedWearables[slot] != _tokenIdToUnequip) continue;
+            if (_aavegotchi.equippedWearables[slot] != _tokenIdToUnequip) continue;
             if(_gotchiInfo.equippedDelegatedItems[slot].nonce != _nonce || _gotchiInfo.equippedDelegatedItems[slot].grantor != _grantor) continue;
             
-            s.aavegotchis[_gotchiId].equippedWearables[slot] = 0;
+            delete _aavegotchi.equippedWearables[slot];
             delete _gotchiInfo.equippedDelegatedItems[slot];
             _unequippedBalance++;
         }
 
+        if(_unequippedBalance == 0) return;
         LibItems.removeFromParent(address(this), _gotchiId, _tokenIdToUnequip, _unequippedBalance);
         emit LibERC1155.TransferFromParent(address(this), _gotchiId, _tokenIdToUnequip, _unequippedBalance);
         _gotchiInfo.equippedDelegatedItemsCount -= _unequippedBalance;

--- a/contracts/Aavegotchi/facets/ItemsRolesRegistryFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsRolesRegistryFacet.sol
@@ -208,8 +208,8 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         uint256 _equippedGotchisLength = s.depositIdToEquippedGotchis[_grantor][_nonce].length();
 
         for(uint256 i; i < _equippedGotchisLength; i++) {
-            uint256 _gotchiId = s.depositIdToEquippedGotchis[_grantor][_depositId].at(i);
-            _unequipDelegatedWearable(_gotchiId, _tokenIdToUnequip, _grantor, _depositId);
+            uint256 _gotchiId = s.depositIdToEquippedGotchis[_grantor][_nonce].at(i);
+            _unequipDelegatedWearable(_gotchiId, _tokenIdToUnequip, _grantor, _nonce);
         }
 
         delete s.depositIdToEquippedGotchis[_grantor][_nonce];

--- a/contracts/Aavegotchi/facets/ItemsRolesRegistryFacet.sol
+++ b/contracts/Aavegotchi/facets/ItemsRolesRegistryFacet.sol
@@ -9,7 +9,7 @@ import {LibItems} from "../libraries/LibItems.sol";
 import {LibMeta} from "../../shared/libraries/LibMeta.sol";
 import {LibERC1155Marketplace} from "../libraries/LibERC1155Marketplace.sol";
 
-import {Modifiers, ItemType, EQUIPPED_WEARABLE_SLOTS, GotchiEquippedItemsInfo, Aavegotchi} from "../libraries/LibAppStorage.sol";
+import {Modifiers, ItemType, EQUIPPED_WEARABLE_SLOTS, GotchiEquippedItemsInfo, Aavegotchi, UserRoleAssignmentsInfo} from "../libraries/LibAppStorage.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import {ERC1155Holder, ERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import {IEventHandlerFacet} from "../WearableDiamond/interfaces/IEventHandlerFacet.sol";
@@ -52,7 +52,10 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
     }
 
     modifier onlyOwnerOrApproved(address _account, address _tokenAddress) {
-        require(_account == LibMeta.msgSender() || isRoleApprovedForAll(_tokenAddress, _account, LibMeta.msgSender()), "ItemsRolesRegistryFacet: account not approved");
+        require(
+            _account == LibMeta.msgSender() || isRoleApprovedForAll(_tokenAddress, _account, LibMeta.msgSender()),
+            "ItemsRolesRegistryFacet: account not approved"
+        );
         _;
     }
 
@@ -63,7 +66,7 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         uint256 _nonce
     ) {
         require(_role == UNIQUE_ROLE, "ItemsRolesRegistryFacet: role not supported");
-        require(_grantee == s.itemsRoleAssignments[_grantor][_nonce].grantee, "ItemsRolesRegistryFacet: grantee mismatch");
+        require(_grantee == s.userRoleAssignmentsInfo[_grantor][_nonce].itemsRoleAssignments.grantee, "ItemsRolesRegistryFacet: grantee mismatch");
         _;
     }
 
@@ -84,19 +87,17 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         )
         onlyOwnerOrApproved(_grantRoleData.grantor, _grantRoleData.tokenAddress)
     {
-        if (s.itemsDeposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenAmount == 0) {
+        UserRoleAssignmentsInfo storage _userInfo = s.userRoleAssignmentsInfo[_grantRoleData.grantor][_grantRoleData.nonce];
+        if (_userInfo.itemsDeposits.tokenAmount == 0) {
             // transfer tokens
             _deposit(_grantRoleData);
         } else {
             // nonce exists
-            require(
-                s.itemsDeposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenAddress == _grantRoleData.tokenAddress,
-                "ItemsRolesRegistryFacet: tokenAddress mismatch"
-            );
-            require(s.itemsDeposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenId == _grantRoleData.tokenId, "ItemsRolesRegistryFacet: tokenId mismatch");
-            require(s.itemsDeposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenAmount == _grantRoleData.tokenAmount, "ItemsRolesRegistryFacet: tokenAmount mismatch");
+            require(_userInfo.itemsDeposits.tokenAddress == _grantRoleData.tokenAddress, "ItemsRolesRegistryFacet: tokenAddress mismatch");
+            require(_userInfo.itemsDeposits.tokenId == _grantRoleData.tokenId, "ItemsRolesRegistryFacet: tokenId mismatch");
+            require(_userInfo.itemsDeposits.tokenAmount == _grantRoleData.tokenAmount, "ItemsRolesRegistryFacet: tokenAmount mismatch");
 
-            RoleData storage _roleData = s.itemsRoleAssignments[_grantRoleData.grantor][_grantRoleData.nonce];
+            RoleData storage _roleData = _userInfo.itemsRoleAssignments;
             require(
                 _roleData.expirationDate < block.timestamp || _roleData.revocable,
                 "ItemsRolesRegistryFacet: nonce is not expired or is not revocable"
@@ -105,9 +106,15 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         _grantOrUpdateRole(_grantRoleData);
     }
 
-    function revokeRoleFrom(bytes32 _role, uint256 _nonce, address _grantor, address _grantee) external override validRoleAndGrantee(_role, _grantor, _grantee, _nonce) {
-        RoleData memory _roleData = s.itemsRoleAssignments[_grantor][_nonce];
-        DepositInfo memory _depositInfo = s.itemsDeposits[_grantor][_nonce];
+    function revokeRoleFrom(
+        bytes32 _role,
+        uint256 _nonce,
+        address _grantor,
+        address _grantee
+    ) external override validRoleAndGrantee(_role, _grantor, _grantee, _nonce) {
+        UserRoleAssignmentsInfo storage _userInfo = s.userRoleAssignmentsInfo[_grantor][_nonce];
+        RoleData memory _roleData = _userInfo.itemsRoleAssignments;
+        DepositInfo memory _depositInfo = _userInfo.itemsDeposits;
 
         address caller = _findCaller(_grantor, _roleData.grantee, _depositInfo.tokenAddress);
         if (_roleData.expirationDate > block.timestamp && !_roleData.revocable) {
@@ -116,34 +123,30 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         }
 
         _unequipAllDelegatedWearables(_nonce, _grantor, _depositInfo.tokenId);
-        
-        s.itemsDepositsUnequippedBalance[_grantor][_nonce] = s.itemsDeposits[_grantor][_nonce].tokenAmount;
-        delete s.itemsRoleAssignments[_grantor][_nonce];
 
-        emit RoleRevoked(
-            _nonce,
-            UNIQUE_ROLE,
-            _depositInfo.tokenAddress,
-            _depositInfo.tokenId,
-            _depositInfo.tokenAmount,
-            _grantor,
-            _roleData.grantee
-        );
+        _userInfo.itemsDepositsUnequippedBalance = _userInfo.itemsDeposits.tokenAmount;
+        delete _userInfo.itemsRoleAssignments;
+
+        emit RoleRevoked(_nonce, UNIQUE_ROLE, _depositInfo.tokenAddress, _depositInfo.tokenId, _depositInfo.tokenAmount, _grantor, _roleData.grantee);
     }
 
-    function withdrawFrom(uint256 _nonce, address _grantor) override external onlyOwnerOrApproved(_grantor, s.itemsDeposits[_grantor][_nonce].tokenAddress) {
-        DepositInfo memory _depositInfo = s.itemsDeposits[_grantor][_nonce];
+    function withdrawFrom(
+        uint256 _nonce,
+        address _grantor
+    ) external override onlyOwnerOrApproved(_grantor, s.userRoleAssignmentsInfo[_grantor][_nonce].itemsDeposits.tokenAddress) {
+        UserRoleAssignmentsInfo storage _userInfo = s.userRoleAssignmentsInfo[_grantor][_nonce];
+        DepositInfo memory _depositInfo = _userInfo.itemsDeposits;
         require(_depositInfo.tokenAmount > 0, "ItemsRolesRegistryFacet: nonce does not exist");
         require(
-            s.itemsRoleAssignments[_grantor][_nonce].expirationDate < block.timestamp || s.itemsRoleAssignments[_grantor][_nonce].revocable,
+            _userInfo.itemsRoleAssignments.expirationDate < block.timestamp || _userInfo.itemsRoleAssignments.revocable,
             "ItemsRolesRegistryFacet: token has an active role"
         );
-        
+
         _unequipAllDelegatedWearables(_nonce, _grantor, _depositInfo.tokenId); // If the item is equipped in some gotchi, it will be unequipped
-        
-        delete s.itemsDeposits[_grantor][_nonce];
-        delete s.itemsDepositsUnequippedBalance[_grantor][_nonce];
-        delete s.itemsRoleAssignments[_grantor][_nonce];
+
+        delete _userInfo.itemsDeposits;
+        delete _userInfo.itemsDepositsUnequippedBalance;
+        delete _userInfo.itemsRoleAssignments;
 
         _transferFrom(address(this), _grantor, _depositInfo.tokenAddress, _depositInfo.tokenId, _depositInfo.tokenAmount);
 
@@ -163,17 +166,16 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         address _grantor,
         address _grantee
     ) external view override validRoleAndGrantee(_role, _grantor, _grantee, _nonce) returns (RoleData memory) {
-        return s.itemsRoleAssignments[_grantor][_nonce];
+        return s.userRoleAssignmentsInfo[_grantor][_nonce].itemsRoleAssignments;
     }
 
     function roleExpirationDate(
         bytes32 _role,
-
         uint256 _nonce,
         address _grantor,
         address _grantee
     ) external view override validRoleAndGrantee(_role, _grantor, _grantee, _nonce) returns (uint64 expirationDate_) {
-        return s.itemsRoleAssignments[_grantor][_nonce].expirationDate;
+        return s.userRoleAssignmentsInfo[_grantor][_nonce].itemsRoleAssignments.expirationDate;
     }
 
     function isRoleApprovedForAll(address _tokenAddress, address _grantor, address _operator) public view override returns (bool) {
@@ -183,7 +185,8 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
     /** Helper Functions **/
 
     function _grantOrUpdateRole(RoleAssignment calldata _grantRoleData) internal {
-        s.itemsRoleAssignments[_grantRoleData.grantor][_grantRoleData.nonce] = RoleData(
+        UserRoleAssignmentsInfo storage _userInfo = s.userRoleAssignmentsInfo[_grantRoleData.grantor][_grantRoleData.nonce];
+        _userInfo.itemsRoleAssignments = RoleData(
             _grantRoleData.grantee,
             _grantRoleData.expirationDate,
             _grantRoleData.revocable,
@@ -205,14 +208,15 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
     }
 
     function _unequipAllDelegatedWearables(uint256 _nonce, address _grantor, uint256 _tokenIdToUnequip) internal {
-        uint256 _equippedGotchisLength = s.depositIdToEquippedGotchis[_grantor][_nonce].length();
+        UserRoleAssignmentsInfo storage _userInfo = s.userRoleAssignmentsInfo[_grantor][_nonce];
+        uint256 _equippedGotchisLength = _userInfo.depositIdToEquippedGotchis.length();
 
-        for(uint256 i; i < _equippedGotchisLength; i++) {
-            uint256 _gotchiId = s.depositIdToEquippedGotchis[_grantor][_nonce].at(i);
+        for (uint256 i; i < _equippedGotchisLength; i++) {
+            uint256 _gotchiId = _userInfo.depositIdToEquippedGotchis.at(i);
             _unequipDelegatedWearable(_gotchiId, _tokenIdToUnequip, _grantor, _nonce);
         }
 
-        delete s.depositIdToEquippedGotchis[_grantor][_nonce];
+        delete _userInfo.depositIdToEquippedGotchis;
     }
 
     function _unequipDelegatedWearable(uint256 _gotchiId, uint256 _tokenIdToUnequip, address _grantor, uint256 _nonce) internal {
@@ -221,14 +225,14 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
         uint256 _unequippedBalance;
         for (uint256 slot; slot < EQUIPPED_WEARABLE_SLOTS; slot++) {
             if (_aavegotchi.equippedWearables[slot] != _tokenIdToUnequip) continue;
-            if(_gotchiInfo.equippedDelegatedItems[slot].nonce != _nonce || _gotchiInfo.equippedDelegatedItems[slot].grantor != _grantor) continue;
-            
+            if (_gotchiInfo.equippedDelegatedItems[slot].nonce != _nonce || _gotchiInfo.equippedDelegatedItems[slot].grantor != _grantor) continue;
+
             delete _aavegotchi.equippedWearables[slot];
             delete _gotchiInfo.equippedDelegatedItems[slot];
             _unequippedBalance++;
         }
 
-        if(_unequippedBalance == 0) return;
+        if (_unequippedBalance == 0) return;
         LibItems.removeFromParent(address(this), _gotchiId, _tokenIdToUnequip, _unequippedBalance);
         emit LibERC1155.TransferFromParent(address(this), _gotchiId, _tokenIdToUnequip, _unequippedBalance);
         _gotchiInfo.equippedDelegatedItemsCount -= _unequippedBalance;
@@ -255,12 +259,9 @@ contract ItemsRolesRegistryFacet is Modifiers, ISftRolesRegistry, ERC1155Holder 
     }
 
     function _deposit(RoleAssignment calldata _grantRoleData) internal {
-        s.itemsDeposits[_grantRoleData.grantor][_grantRoleData.nonce] = DepositInfo(
-            _grantRoleData.tokenAddress,
-            _grantRoleData.tokenId,
-            _grantRoleData.tokenAmount
-        );
-        s.itemsDepositsUnequippedBalance[_grantRoleData.grantor][_grantRoleData.nonce] = _grantRoleData.tokenAmount;
+        UserRoleAssignmentsInfo storage _userInfo = s.userRoleAssignmentsInfo[_grantRoleData.grantor][_grantRoleData.nonce];
+        _userInfo.itemsDeposits = DepositInfo(_grantRoleData.tokenAddress, _grantRoleData.tokenId, _grantRoleData.tokenAmount);
+        _userInfo.itemsDepositsUnequippedBalance = _grantRoleData.tokenAmount;
 
         _transferFrom(_grantRoleData.grantor, address(this), _grantRoleData.tokenAddress, _grantRoleData.tokenId, _grantRoleData.tokenAmount);
     }

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -221,20 +221,15 @@ struct ERC721BuyOrder {
     bool[] validationOptions;
 }
 
-struct EquippedDelegatedItemInfo {
-    ItemDepositId depositId;
-    uint256 balance;
-}
-
 struct ItemDepositId {
     uint256 nonce;
     address grantor;
 }
 
 struct GotchiEquippedItemsInfo {
-    // wearableTokenId => equippedItemIdToDelegationInfo
-    mapping(uint256 => EquippedDelegatedItemInfo) equippedItemIdToDelegationInfo;
-    uint256 equippedDelegateItemsCount;
+    // slotPosition => depositId
+    mapping(uint256 => ItemDepositId) equippedDelegatedItems;
+    uint256 equippedDelegatedItemsCount;
 }
 
 struct AppStorage {

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -232,11 +232,11 @@ struct GotchiEquippedItemsInfo {
     uint256 equippedDelegatedItemsCount;
 }
 
-struct UserRoleAssignmentsInfo {
-ISftRolesRegistry.DepositInfo itemsDeposits;
-ISftRolesRegistry.RoleData itemsRoleAssignments;
-EnumerableSet.UintSet depositIdToEquippedGotchis;
-uint256 itemsDepositsUnequippedBalance;
+struct UserDelegatedItemsInfo {
+ISftRolesRegistry.DepositInfo deposit;
+ISftRolesRegistry.RoleData roleAssignment;
+EnumerableSet.UintSet equippedGotchis;
+uint256 availableBalance;
 }
 
 struct AppStorage {
@@ -361,7 +361,7 @@ struct AppStorage {
     
     // Items Roles Registry
     // grantor => nonce => userRoleAssignmentsInfo
-    mapping(address => mapping(uint256 => UserRoleAssignmentsInfo)) userRoleAssignmentsInfo;
+    mapping(address => mapping(uint256 => UserDelegatedItemsInfo)) userDelegatedItemsInfo;
     // grantor => tokenAddress => operator => isApproved
     mapping(address => mapping(address => mapping(address => bool))) itemsRoleApprovals;
     

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -233,10 +233,10 @@ struct GotchiEquippedItemsInfo {
 }
 
 struct UserDelegatedItemsInfo {
-ISftRolesRegistry.DepositInfo deposit;
-ISftRolesRegistry.RoleData roleAssignment;
-EnumerableSet.UintSet equippedGotchis;
-uint256 availableBalance;
+    ISftRolesRegistry.DepositInfo deposit;
+    ISftRolesRegistry.RoleData roleAssignment;
+    EnumerableSet.UintSet equippedGotchis;
+    uint256 availableBalance;
 }
 
 struct AppStorage {

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -232,6 +232,13 @@ struct GotchiEquippedItemsInfo {
     uint256 equippedDelegatedItemsCount;
 }
 
+struct UserRoleAssignmentsInfo {
+ISftRolesRegistry.DepositInfo itemsDeposits;
+ISftRolesRegistry.RoleData itemsRoleAssignments;
+EnumerableSet.UintSet depositIdToEquippedGotchis;
+uint256 itemsDepositsUnequippedBalance;
+}
+
 struct AppStorage {
     mapping(address => AavegotchiCollateralTypeInfo) collateralTypeInfo;
     mapping(address => uint256) collateralTypeIndexes;
@@ -353,19 +360,12 @@ struct AppStorage {
     mapping(address => mapping(uint256 => mapping(address => uint256))) buyerToBuyOrderId; // erc721 token address => erc721TokenId => sender => buyOrderId
     
     // Items Roles Registry
-    // grantor => depositId => DepositInfo
-    mapping(address => mapping(uint256 => ISftRolesRegistry.DepositInfo)) itemsDeposits;
-    // grantor => depositId  => RoleAssignment
-    mapping(address =>  mapping(uint256 => ISftRolesRegistry.RoleData)) itemsRoleAssignments;
+    // grantor => nonce => userRoleAssignmentsInfo
+    mapping(address => mapping(uint256 => UserRoleAssignmentsInfo)) userRoleAssignmentsInfo;
     // grantor => tokenAddress => operator => isApproved
     mapping(address => mapping(address => mapping(address => bool))) itemsRoleApprovals;
     
-
     // Auxilliary structs for Items Roles Registry
-    // grantor => depositId => gotchiIds
-    mapping(address => mapping(uint256 => EnumerableSet.UintSet)) depositIdToEquippedGotchis;
-    // grantor => depositId => remainingBalance
-    mapping(address => mapping(uint256 => uint256)) itemsDepositsUnequippedBalance;
     // gotchiId => equippedItemsInfo
     mapping(uint256 => GotchiEquippedItemsInfo) gotchiEquippedItemsInfo;
 }

--- a/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
+++ b/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
@@ -782,6 +782,154 @@ describe("ItemsRolesRegistryFacet", async () => {
         .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[3], 1)
         .to.not.emit(libEventHandler, "TransferSingle");
     })
+    it("should equip and unequip two gloves one not and one delegated", async () => {
+      await wearablesFacet
+        .connect(grantor)
+        .safeTransferFrom(
+          grantor.address,
+          LargeGotchiOwner,
+          wearableIds[0],
+          1,
+          "0x"
+        );
+
+      const granteeAddress = await grantee.getAddress();
+      const newRoleAssignment1 = await buildRoleAssignment({
+        tokenAddress: wearablesFacet.address,
+        tokenId: wearableIds[0],
+        grantor: grantor.address,
+        grantee: granteeAddress,
+        tokenAmount: 1,
+      });
+
+      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+        newRoleAssignment1
+      )
+
+      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+        nonce: 0,
+        grantor: AddressZero,
+      });
+
+      itemDepositIds[4] = {
+        nonce: newRoleAssignment1.nonce,
+        grantor: newRoleAssignment1.grantor,
+      };
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            itemDepositIds
+          )
+      )
+        .to.emit(libERC1155, "TransferToParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+        .to.emit(libEventHandler, "TransferSingle")
+        .withArgs(
+          granteeAddress,
+          granteeAddress,
+          aavegotchiDiamondAddress,
+          wearableIds[0],
+          1
+        )
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            emptyWearableIds,
+            emptyItemDepositIds
+          )
+      ).to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+        .to.emit(libERC1155, "TransferFromParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+    })
+    it('should equip and unequp two gloves one delegated one not', async () => {
+      await wearablesFacet
+        .connect(grantor)
+        .safeTransferFrom(
+          grantor.address,
+          LargeGotchiOwner,
+          wearableIds[0],
+          1,
+          "0x"
+        );
+
+      const granteeAddress = await grantee.getAddress();
+      const newRoleAssignment1 = await buildRoleAssignment({
+        tokenAddress: wearablesFacet.address,
+        tokenId: wearableIds[0],
+        grantor: grantor.address,
+        grantee: granteeAddress,
+        tokenAmount: 1,
+      });
+
+      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+        newRoleAssignment1
+      )
+
+      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+        nonce: 0,
+        grantor: AddressZero,
+      });
+
+      itemDepositIds[5] = {
+        nonce: newRoleAssignment1.nonce,
+        grantor: newRoleAssignment1.grantor,
+      };
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            itemDepositIds
+          )
+      )
+        .to.emit(libERC1155, "TransferToParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+        .to.emit(libEventHandler, "TransferSingle")
+        .withArgs(
+          granteeAddress,
+          granteeAddress,
+          aavegotchiDiamondAddress,
+          wearableIds[0],
+          1
+        )
+
+      await expect(
+        itemsFacet
+          .connect(grantee)
+          .equipDelegatedWearables(
+            anotherGotchiId,
+            emptyWearableIds,
+            emptyItemDepositIds
+          )
+      ).to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+        .to.emit(libERC1155, "TransferFromParent")
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+    })
     it('should NOT transfer an aavegotchi with mixed wearables equipped', async () => {
       await wearablesFacet
         .connect(grantor)

--- a/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
+++ b/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
@@ -76,7 +76,7 @@ describe("ItemsFacet", async () => {
       facetNames: [
         "ItemsRolesRegistryFacet",
         "contracts/Aavegotchi/facets/ItemsFacet.sol:ItemsFacet",
-        "contracts/Aavegotchi/facets/AavegotchiFacet.sol:AavegotchiFacet"
+        "contracts/Aavegotchi/facets/AavegotchiFacet.sol:AavegotchiFacet",
       ],
       signer: diamondOwner,
     });
@@ -123,7 +123,10 @@ describe("ItemsFacet", async () => {
       signer
     );
 
-    await daoFacet.updateItemTypeMaxQuantity(wearableIds, wearableIds.map(() => 2000));
+    await daoFacet.updateItemTypeMaxQuantity(
+      wearableIds,
+      wearableIds.map(() => 2000)
+    );
     await daoFacet.mintItems(
       grantor.address,
       wearableIds,
@@ -352,7 +355,8 @@ describe("ItemsFacet", async () => {
           aavegotchiDiamondAddress,
           wearableIds[0],
           1
-        ).to.emit(libEventHandler, "TransferSingle")
+        )
+        .to.emit(libEventHandler, "TransferSingle")
         .withArgs(
           LargeGotchiOwner,
           LargeGotchiOwner,
@@ -744,514 +748,154 @@ describe("ItemsFacet", async () => {
           2
         );
     });
-    it('should NOT transfer an aavegotchi with delegated wearable equipped', async () => {
-      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: BigNumber.from(0),
-        grantor: AddressZero,
-      });
+    describe("edge cases", () => {
+      it("should NOT transfer an aavegotchi with delegated wearable equipped", async () => {
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: BigNumber.from(0),
+          grantor: AddressZero,
+        });
 
-      itemDepositIds[3] = {
-        nonce: RoleAssignment.nonce,
-        grantor: RoleAssignment.grantor,
-      };
+        itemDepositIds[3] = {
+          nonce: RoleAssignment.nonce,
+          grantor: RoleAssignment.grantor,
+        };
 
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, wearableIds[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[3], 1)
-        .to.not.emit(libEventHandler, "TransferSingle");
-
-      await expect(
-        aavegotchiFacet.connect(grantee).transferFrom(
-          await grantee.getAddress(),
-          grantor.address,
-          anotherGotchiId,
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [0, 0, 0, wearableIds[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              itemDepositIds
+            )
         )
-      ).to.be.revertedWith("AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
-      
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            emptyWearableIds,
-            emptyItemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferFromParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[3], 1)
-        .to.not.emit(libEventHandler, "TransferSingle");
-    })
-    it("should equip and unequip two gloves one not and one delegated", async () => {
-      await wearablesFacet
-        .connect(grantor)
-        .safeTransferFrom(
-          grantor.address,
-          LargeGotchiOwner,
-          wearableIds[0],
-          1,
-          "0x"
-        );
-
-      const granteeAddress = await grantee.getAddress();
-      const newRoleAssignment1 = await buildRoleAssignment({
-        tokenAddress: wearablesFacet.address,
-        tokenId: wearableIds[0],
-        grantor: grantor.address,
-        grantee: granteeAddress,
-        tokenAmount: 1,
-      });
-
-      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
-        newRoleAssignment1
-      )
-
-      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: 0,
-        grantor: AddressZero,
-      });
-
-      itemDepositIds[4] = {
-        nonce: newRoleAssignment1.nonce,
-        grantor: newRoleAssignment1.grantor,
-      };
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-        .to.emit(libEventHandler, "TransferSingle")
-        .withArgs(
-          granteeAddress,
-          granteeAddress,
-          aavegotchiDiamondAddress,
-          wearableIds[0],
-          1
-        )
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            emptyWearableIds,
-            emptyItemDepositIds
-          )
-      ).to.emit(libEventHandler, "TransferSingle")
+          .to.emit(libERC1155, "TransferToParent")
           .withArgs(
-            granteeAddress,
             aavegotchiDiamondAddress,
-            granteeAddress,
-            wearableIds[0],
+            anotherGotchiId,
+            wearableIds[3],
             1
           )
-        .to.emit(libERC1155, "TransferFromParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-    })
-    it('should equip and unequp two gloves one delegated one not', async () => {
-      await wearablesFacet
-        .connect(grantor)
-        .safeTransferFrom(
-          grantor.address,
-          LargeGotchiOwner,
-          wearableIds[0],
-          1,
-          "0x"
+          .to.not.emit(libEventHandler, "TransferSingle");
+
+        await expect(
+          aavegotchiFacet
+            .connect(grantee)
+            .transferFrom(
+              await grantee.getAddress(),
+              grantor.address,
+              anotherGotchiId
+            )
+        ).to.be.revertedWith(
+          "AavegotchiFacet: Can't transfer when equipped with a delegated wearable"
         );
 
-      const granteeAddress = await grantee.getAddress();
-      const newRoleAssignment1 = await buildRoleAssignment({
-        tokenAddress: wearablesFacet.address,
-        tokenId: wearableIds[0],
-        grantor: grantor.address,
-        grantee: granteeAddress,
-        tokenAmount: 1,
-      });
-
-      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
-        newRoleAssignment1
-      )
-
-      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: 0,
-        grantor: AddressZero,
-      });
-
-      itemDepositIds[5] = {
-        nonce: newRoleAssignment1.nonce,
-        grantor: newRoleAssignment1.grantor,
-      };
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-        .to.emit(libEventHandler, "TransferSingle")
-        .withArgs(
-          granteeAddress,
-          granteeAddress,
-          aavegotchiDiamondAddress,
-          wearableIds[0],
-          1
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              emptyWearableIds,
+              emptyItemDepositIds
+            )
         )
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            emptyWearableIds,
-            emptyItemDepositIds
-          )
-      ).to.emit(libEventHandler, "TransferSingle")
+          .to.emit(libERC1155, "TransferFromParent")
           .withArgs(
-            granteeAddress,
             aavegotchiDiamondAddress,
-            granteeAddress,
-            wearableIds[0],
+            anotherGotchiId,
+            wearableIds[3],
             1
           )
-        .to.emit(libERC1155, "TransferFromParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-    })
-    it('should equip two gloves one delegated and one not and unequip one first and then another', async () => {
-      await wearablesFacet
-        .connect(grantor)
-        .safeTransferFrom(
-          grantor.address,
-          LargeGotchiOwner,
-          wearableIds[0],
-          1,
-          "0x"
-        );
-
-      const granteeAddress = await grantee.getAddress();
-      const newRoleAssignment1 = await buildRoleAssignment({
-        tokenAddress: wearablesFacet.address,
-        tokenId: wearableIds[0],
-        grantor: grantor.address,
-        grantee: granteeAddress,
-        tokenAmount: 1,
+          .to.not.emit(libEventHandler, "TransferSingle");
       });
-
-      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
-        newRoleAssignment1
-      )
-
-      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: 0,
-        grantor: AddressZero,
-      });
-
-      itemDepositIds[5] = {
-        nonce: newRoleAssignment1.nonce,
-        grantor: newRoleAssignment1.grantor,
-      };
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-        .to.emit(libEventHandler, "TransferSingle")
-        .withArgs(
-          granteeAddress,
-          granteeAddress,
-          aavegotchiDiamondAddress,
-          wearableIds[0],
-          1
-        )
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            emptyItemDepositIds
-          )
-      ).to.emit(libERC1155, "TransferFromParent")
-      .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-      .to.not.emit(libEventHandler, "TransferSingle")
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            emptyItemDepositIds
-          )
-      ).to.emit(libEventHandler, "TransferSingle")
-      .withArgs(
-        granteeAddress,
-        aavegotchiDiamondAddress,
-        granteeAddress,
-        wearableIds[0],
-        1
-      )
-      .to.emit(libERC1155, "TransferFromParent")
-      .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-    })
-    it('should NOT transfer an aavegotchi with mixed wearables equipped', async () => {
-      await wearablesFacet
-        .connect(grantor)
-        .safeTransferFrom(
-          grantor.address,
-          LargeGotchiOwner,
-          wearableIds[0],
-          2,
-          "0x"
-        );
-
-      const granteeAddress = await grantee.getAddress();
-      const newRoleAssignment1 = await buildRoleAssignment({
-        tokenAddress: wearablesFacet.address,
-        tokenId: wearableIds[1],
-        grantor: grantor.address,
-        grantee: granteeAddress,
-        tokenAmount: 1,
-      });
-
-      const newRoleAssignment2 = await buildRoleAssignment({
-        tokenAddress: wearablesFacet.address,
-        tokenId: wearableIds[5],
-        grantor: grantor.address,
-        grantee: granteeAddress,
-        tokenAmount: 1,
-      });
-
-      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
-        newRoleAssignment1
-      )
-      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
-        newRoleAssignment2
-      );
-
-      const anotherGotchiId = LargeGotchiOwnerAavegotchis[2];
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: BigNumber.from(0),
-        grantor: AddressZero,
-      });
-
-      itemDepositIds[2] = {
-        nonce: newRoleAssignment1.nonce,
-        grantor: newRoleAssignment1.grantor,
-      };
-      itemDepositIds[3] = {
-        nonce: RoleAssignment.nonce,
-        grantor: RoleAssignment.grantor,
-      };
-      itemDepositIds[6] = {
-        nonce: newRoleAssignment2.nonce,
-        grantor: newRoleAssignment2.grantor,
-      };
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, wearableIds[1], wearableIds[3], wearableIds[0], wearableIds[0], wearableIds[5], 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[3], 1)
-        .to.emit(libEventHandler, "TransferSingle")
-        .withArgs(
-          LargeGotchiOwner,
-          LargeGotchiOwner,
-          aavegotchiDiamondAddress,
-          wearableIds[0],
-          1
-        ).to.emit(libEventHandler, "TransferSingle")
-        .withArgs(
-          LargeGotchiOwner,
-          LargeGotchiOwner,
-          aavegotchiDiamondAddress,
-          wearableIds[0],
-          1
-        )
-
-      await expect(aavegotchiFacet.connect(grantee).transferFrom(granteeAddress, grantor.address, anotherGotchiId))
-        .to.be.revertedWith("AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
-
-      // Unequip wearables [1] and [3]
-      itemDepositIds[2] = {
-        nonce: 0,
-        grantor: AddressZero,
-      };
-      itemDepositIds[3] = {
-        nonce: 0,
-        grantor: AddressZero,
-      };
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], wearableIds[0], wearableIds[5], 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      ).to.emit(libERC1155, "TransferFromParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[1], 1)
-        .to.emit(libERC1155, "TransferFromParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[3], 1)
-        .to.not.emit(libEventHandler, "TransferSingle");
-
-        await expect(aavegotchiFacet.connect(grantee).transferFrom(granteeAddress, grantor.address, anotherGotchiId))
-        .to.be.revertedWith("AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
-      // Unequip wearables [0]
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, 0, 0, wearableIds[5], 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      ).to.emit(libEventHandler, "TransferSingle")
-          .withArgs(
-            granteeAddress,
-            aavegotchiDiamondAddress,
-            granteeAddress,
+      it("should equip and unequip two gloves one not and one delegated", async () => {
+        await wearablesFacet
+          .connect(grantor)
+          .safeTransferFrom(
+            grantor.address,
+            LargeGotchiOwner,
             wearableIds[0],
-            1
-          )
-        .to.emit(libEventHandler, "TransferSingle")
-          .withArgs(
-            granteeAddress,
-            aavegotchiDiamondAddress,
-            granteeAddress,
-            wearableIds[0],
-            1
-          )
-        
-      await expect(aavegotchiFacet.connect(grantee).transferFrom(granteeAddress, grantor.address, anotherGotchiId))
-      .to.be.revertedWith("AavegotchiFacet: Can't transfer when equipped with a delegated wearable");
+            1,
+            "0x"
+          );
 
-      // Unequip wearables [5]
-      itemDepositIds[6] = {
-        nonce: 0,
-        grantor: AddressZero,
-      };
+        const granteeAddress = await grantee.getAddress();
+        const newRoleAssignment1 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[0],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 1,
+        });
 
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      ).to.emit(libERC1155, "TransferFromParent")
-      .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[5], 1)
-      .to.not.emit(libEventHandler, "TransferSingle");
-
-      await expect(aavegotchiFacet.connect(grantee).transferFrom(granteeAddress, grantor.address, anotherGotchiId)).to.not.be.reverted;
-    })
-    it('should equip and unequp two gloves one delegated one not and then equip another of the same delegation and id', async () => {
-      await wearablesFacet
-        .connect(grantor)
-        .safeTransferFrom(
-          grantor.address,
-          LargeGotchiOwner,
-          wearableIds[0],
-          1,
-          "0x"
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+          newRoleAssignment1
         );
 
-      const granteeAddress = await grantee.getAddress();
-      const newRoleAssignment1 = await buildRoleAssignment({
-        tokenAddress: wearablesFacet.address,
-        tokenId: wearableIds[0],
-        grantor: grantor.address,
-        grantee: granteeAddress,
-        tokenAmount: 2,
-      });
-
-      await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
-        newRoleAssignment1
-      )
-
-      const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: 0,
-        grantor: AddressZero,
-      });
-
-      itemDepositIds[5] = {
-        nonce: newRoleAssignment1.nonce,
-        grantor: newRoleAssignment1.grantor,
-      };
-
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
-          )
-      )
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-        .to.emit(libEventHandler, "TransferSingle")
-        .withArgs(
-          granteeAddress,
-          granteeAddress,
-          aavegotchiDiamondAddress,
-          wearableIds[0],
-          1
-        )
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: 0,
+          grantor: AddressZero,
+        });
 
         itemDepositIds[4] = {
           nonce: newRoleAssignment1.nonce,
           grantor: newRoleAssignment1.grantor,
         };
 
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                0,
+                0,
+                wearableIds[0],
+                wearableIds[0],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferToParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
             anotherGotchiId,
-            [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
+            wearableIds[0],
+            1
           )
-      ).to.emit(libEventHandler, "TransferSingle")
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            wearableIds[0],
+            1
+          );
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              emptyWearableIds,
+              emptyItemDepositIds
+            )
+        )
+          .to.emit(libEventHandler, "TransferSingle")
           .withArgs(
             granteeAddress,
             aavegotchiDiamondAddress,
@@ -1259,31 +903,669 @@ describe("ItemsFacet", async () => {
             wearableIds[0],
             1
           )
-        .to.emit(libERC1155, "TransferFromParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-        .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
-    })
-    it("should NOT equip a delegated wearable if the depositId is expired", async () => {
-      await network.provider.send("evm_increaseTime", [ONE_DAY]);
-      const itemDepositIds: ItemDepositId[] = new Array(16).fill({
-        nonce: BigNumber.from(0),
-        grantor: AddressZero,
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          );
       });
-      itemDepositIds[3] = {
-        nonce: RoleAssignment.nonce,
-        grantor: RoleAssignment.grantor,
-      };
+      it("should equip and unequp two gloves one delegated one not", async () => {
+        await wearablesFacet
+          .connect(grantor)
+          .safeTransferFrom(
+            grantor.address,
+            LargeGotchiOwner,
+            wearableIds[0],
+            1,
+            "0x"
+          );
 
-      await expect(
-        itemsFacet
-          .connect(grantee)
-          .equipDelegatedWearables(
-            gotchiId,
-            [0, 0, 0, wearableIds[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            itemDepositIds
+        const granteeAddress = await grantee.getAddress();
+        const newRoleAssignment1 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[0],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 1,
+        });
+
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+          newRoleAssignment1
+        );
+
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: 0,
+          grantor: AddressZero,
+        });
+
+        itemDepositIds[5] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                0,
+                0,
+                wearableIds[0],
+                wearableIds[0],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferToParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
           )
-      ).to.be.revertedWith("ItemsFacet: Wearable delegation expired");
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            wearableIds[0],
+            1
+          );
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              emptyWearableIds,
+              emptyItemDepositIds
+            )
+        )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          );
+      });
+      it("should equip two gloves one delegated and one not and unequip the left hand first and then the right", async () => {
+        await wearablesFacet
+          .connect(grantor)
+          .safeTransferFrom(
+            grantor.address,
+            LargeGotchiOwner,
+            wearableIds[0],
+            1,
+            "0x"
+          );
+
+        const granteeAddress = await grantee.getAddress();
+        const newRoleAssignment1 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[0],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 1,
+        });
+
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+          newRoleAssignment1
+        );
+
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: 0,
+          grantor: AddressZero,
+        });
+
+        itemDepositIds[5] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                0,
+                0,
+                wearableIds[0],
+                wearableIds[0],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferToParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            wearableIds[0],
+            1
+          );
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [0, 0, 0, 0, wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              emptyItemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          )
+          .to.not.emit(libEventHandler, "TransferSingle");
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              emptyItemDepositIds
+            )
+        )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          );
+      });
+      it('should equip two gloves one both delegated and unequip the right hand first and then the left with revokeRoleFrom', async () => {
+        const granteeAddress = await grantee.getAddress();
+        const newRoleAssignment1 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[0],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 2
+        });
+
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(newRoleAssignment1);
+
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({nonce: 0, grantor: AddressZero});
+
+        itemDepositIds[4] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor
+        };
+        itemDepositIds[5] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor
+        };
+
+        await expect(itemsFacet.connect(grantee).equipDelegatedWearables(anotherGotchiId, [0, 0, 0, 0, wearableIds[0], wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], itemDepositIds))
+          .to.emit(libERC1155, 'TransferToParent')
+          .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+          .to.emit(libERC1155, 'TransferToParent')
+          .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+
+         itemDepositIds[5] = {
+          nonce: 0,
+          grantor: AddressZero
+        };
+
+        await expect(itemsFacet.connect(grantee).equipDelegatedWearables(anotherGotchiId, [0, 0, 0, 0, wearableIds[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], itemDepositIds))
+          .to.emit(libERC1155, 'TransferFromParent')
+          .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+          .to.not.emit(libEventHandler, 'TransferSingle');
+
+      
+        await expect(ItemsRolesRegistryFacet.connect(grantor).revokeRoleFrom(newRoleAssignment1.role, newRoleAssignment1.nonce, newRoleAssignment1.grantor, newRoleAssignment1.grantee))
+        .to.emit(libERC1155, 'TransferFromParent')
+        .withArgs(aavegotchiDiamondAddress, anotherGotchiId, wearableIds[0], 1)
+      })
+      it("should NOT transfer an aavegotchi with mixed wearables equipped", async () => {
+        await wearablesFacet
+          .connect(grantor)
+          .safeTransferFrom(
+            grantor.address,
+            LargeGotchiOwner,
+            wearableIds[0],
+            2,
+            "0x"
+          );
+
+        const granteeAddress = await grantee.getAddress();
+        const newRoleAssignment1 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[1],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 1,
+        });
+
+        const newRoleAssignment2 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[5],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 1,
+        });
+
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+          newRoleAssignment1
+        );
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+          newRoleAssignment2
+        );
+
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[2];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: BigNumber.from(0),
+          grantor: AddressZero,
+        });
+
+        itemDepositIds[2] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor,
+        };
+        itemDepositIds[3] = {
+          nonce: RoleAssignment.nonce,
+          grantor: RoleAssignment.grantor,
+        };
+        itemDepositIds[6] = {
+          nonce: newRoleAssignment2.nonce,
+          grantor: newRoleAssignment2.grantor,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                wearableIds[1],
+                wearableIds[3],
+                wearableIds[0],
+                wearableIds[0],
+                wearableIds[5],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferToParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[3],
+            1
+          )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            LargeGotchiOwner,
+            LargeGotchiOwner,
+            aavegotchiDiamondAddress,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            LargeGotchiOwner,
+            LargeGotchiOwner,
+            aavegotchiDiamondAddress,
+            wearableIds[0],
+            1
+          );
+
+        await expect(
+          aavegotchiFacet
+            .connect(grantee)
+            .transferFrom(granteeAddress, grantor.address, anotherGotchiId)
+        ).to.be.revertedWith(
+          "AavegotchiFacet: Can't transfer when equipped with a delegated wearable"
+        );
+
+        // Unequip wearables [1] and [3]
+        itemDepositIds[2] = {
+          nonce: 0,
+          grantor: AddressZero,
+        };
+        itemDepositIds[3] = {
+          nonce: 0,
+          grantor: AddressZero,
+        };
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                0,
+                0,
+                wearableIds[0],
+                wearableIds[0],
+                wearableIds[5],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[1],
+            1
+          )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[3],
+            1
+          )
+          .to.not.emit(libEventHandler, "TransferSingle");
+
+        await expect(
+          aavegotchiFacet
+            .connect(grantee)
+            .transferFrom(granteeAddress, grantor.address, anotherGotchiId)
+        ).to.be.revertedWith(
+          "AavegotchiFacet: Can't transfer when equipped with a delegated wearable"
+        );
+        // Unequip wearables [0]
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [0, 0, 0, 0, 0, 0, wearableIds[5], 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              itemDepositIds
+            )
+        )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          );
+
+        await expect(
+          aavegotchiFacet
+            .connect(grantee)
+            .transferFrom(granteeAddress, grantor.address, anotherGotchiId)
+        ).to.be.revertedWith(
+          "AavegotchiFacet: Can't transfer when equipped with a delegated wearable"
+        );
+
+        // Unequip wearables [5]
+        itemDepositIds[6] = {
+          nonce: 0,
+          grantor: AddressZero,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[5],
+            1
+          )
+          .to.not.emit(libEventHandler, "TransferSingle");
+
+        await expect(
+          aavegotchiFacet
+            .connect(grantee)
+            .transferFrom(granteeAddress, grantor.address, anotherGotchiId)
+        ).to.not.be.reverted;
+      });
+      it("should equip and unequp two gloves one delegated one not and then equip another of the same delegation and id", async () => {
+        await wearablesFacet
+          .connect(grantor)
+          .safeTransferFrom(
+            grantor.address,
+            LargeGotchiOwner,
+            wearableIds[0],
+            1,
+            "0x"
+          );
+
+        const granteeAddress = await grantee.getAddress();
+        const newRoleAssignment1 = await buildRoleAssignment({
+          tokenAddress: wearablesFacet.address,
+          tokenId: wearableIds[0],
+          grantor: grantor.address,
+          grantee: granteeAddress,
+          tokenAmount: 2,
+        });
+
+        await ItemsRolesRegistryFacet.connect(grantor).grantRoleFrom(
+          newRoleAssignment1
+        );
+
+        const anotherGotchiId = LargeGotchiOwnerAavegotchis[1];
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: 0,
+          grantor: AddressZero,
+        });
+
+        itemDepositIds[5] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                0,
+                0,
+                wearableIds[0],
+                wearableIds[0],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libERC1155, "TransferToParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            wearableIds[0],
+            1
+          );
+
+        itemDepositIds[4] = {
+          nonce: newRoleAssignment1.nonce,
+          grantor: newRoleAssignment1.grantor,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              anotherGotchiId,
+              [
+                0,
+                0,
+                0,
+                0,
+                wearableIds[0],
+                wearableIds[0],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+              ],
+              itemDepositIds
+            )
+        )
+          .to.emit(libEventHandler, "TransferSingle")
+          .withArgs(
+            granteeAddress,
+            aavegotchiDiamondAddress,
+            granteeAddress,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libERC1155, "TransferFromParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          )
+          .to.emit(libERC1155, "TransferToParent")
+          .withArgs(
+            aavegotchiDiamondAddress,
+            anotherGotchiId,
+            wearableIds[0],
+            1
+          );
+      });
+      it("should NOT equip a delegated wearable if the depositId is expired", async () => {
+        await network.provider.send("evm_increaseTime", [ONE_DAY]);
+        const itemDepositIds: ItemDepositId[] = new Array(16).fill({
+          nonce: BigNumber.from(0),
+          grantor: AddressZero,
+        });
+        itemDepositIds[3] = {
+          nonce: RoleAssignment.nonce,
+          grantor: RoleAssignment.grantor,
+        };
+
+        await expect(
+          itemsFacet
+            .connect(grantee)
+            .equipDelegatedWearables(
+              gotchiId,
+              [0, 0, 0, wearableIds[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              itemDepositIds
+            )
+        ).to.be.revertedWith("ItemsFacet: Wearable delegation expired");
+      });
     });
   });
 });

--- a/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
+++ b/test/ItemsRolesRegistryFacet/itemsFacetTest.ts
@@ -19,7 +19,6 @@ import {
   LargeGotchiOwner,
   LargeGotchiOwnerAavegotchis,
   aavegotchiDiamondAddress,
-  wearableAmounts,
   wearableDiamondAddress,
   wearableIds,
   RoleAssignment,
@@ -35,7 +34,7 @@ const { expect } = chai;
 
 const AddressZero = ethers.constants.AddressZero;
 
-describe("ItemsRolesRegistryFacet", async () => {
+describe("ItemsFacet", async () => {
   let ItemsRolesRegistryFacet: Contract;
   let grantor: SignerWithAddress;
   let grantee: Signer;
@@ -277,7 +276,9 @@ describe("ItemsRolesRegistryFacet", async () => {
           )
       )
         .to.emit(libERC1155, "TransferToParent")
-        .withArgs(aavegotchiDiamondAddress, gotchiId, wearableIds[0], 2)
+        .withArgs(aavegotchiDiamondAddress, gotchiId, wearableIds[0], 1)
+        .to.emit(libERC1155, "TransferToParent")
+        .withArgs(aavegotchiDiamondAddress, gotchiId, wearableIds[0], 1)
         .to.not.emit(libEventHandler, "TransferSingle");
 
       await expect(
@@ -350,7 +351,14 @@ describe("ItemsRolesRegistryFacet", async () => {
           LargeGotchiOwner,
           aavegotchiDiamondAddress,
           wearableIds[0],
-          2
+          1
+        ).to.emit(libEventHandler, "TransferSingle")
+        .withArgs(
+          LargeGotchiOwner,
+          LargeGotchiOwner,
+          aavegotchiDiamondAddress,
+          wearableIds[0],
+          1
         );
 
       await expect(
@@ -1001,7 +1009,14 @@ describe("ItemsRolesRegistryFacet", async () => {
           LargeGotchiOwner,
           aavegotchiDiamondAddress,
           wearableIds[0],
-          2
+          1
+        ).to.emit(libEventHandler, "TransferSingle")
+        .withArgs(
+          LargeGotchiOwner,
+          LargeGotchiOwner,
+          aavegotchiDiamondAddress,
+          wearableIds[0],
+          1
         )
 
       await expect(aavegotchiFacet.connect(grantee).transferFrom(granteeAddress, grantor.address, anotherGotchiId))

--- a/test/ItemsRolesRegistryFacet/itemsRolesRegistryFacetTest.ts
+++ b/test/ItemsRolesRegistryFacet/itemsRolesRegistryFacetTest.ts
@@ -14,7 +14,6 @@ import {
   buildRoleAssignment,
   generateRandomInt,
   time,
-  wearableAmounts,
   wearableDiamondAddress,
   wearableIds,
   RoleAssignment,
@@ -87,7 +86,7 @@ describe("ItemsRolesRegistryFacet", async () => {
       await ethers.getContractAt("DAOFacet", aavegotchiDiamondAddress)
     ).connect(signer);
 
-    await daoFacet.updateItemTypeMaxQuantity(wearableIds, wearableAmounts);
+    await daoFacet.updateItemTypeMaxQuantity(wearableIds, wearableIds.map(() => 2000));
     await daoFacet.mintItems(
       grantor.address,
       wearableIds,


### PR DESCRIPTION
Edge case 1: 
- Consider a glove id 17
- Consider an grantee has only 1 tokenAmount of glove 17, 
- Consider that the grantee receive a delegation of 1 tokenAmount for glove 17

1. grantee tries to equip both gloves in his gotchi
2. `equipWearables` function will notice that he is equipping both gloves with same id. It will require a needBalance of 2
3. Since grantee doesn't have that balance, transaction will revert

Edge case 2: 
- Consider a glove id 17 
- Consider that the grantee receive a delegation of 1 tokenAmount for glove 17 from grantor1 - delegation 1
- Consider that the grantee receive a delegation of 1 tokenAmount for glove 17 from grantor2 - delegation 2

1. grantee tries to equip both gloves in his gotchi
2. `equipWearables` function will notice that he is equipping both gloves with same id. It will require a needBalance of 2 for delegation1
3. Since delegation1 doesn't have that balance, transaction will revert

Edge case 3 (this can happen in any slot, not exclusive for hands) :
- Consider grantee has 1 tokenAmount of glove 25
- Consider that grantee received a delegation (nonce 444) of 2 tokenAmount for glove 25 from a grantor

1. grantee equips 1 of his gloves and 1 of the delegation ( the array will be [...,25,25,...] for wearableIds and [...,0,444,...] for depositIds )
2. grantee unequip his gloves and equip the other one of the same delegation  ( now the array will be [...,25,25,...] for wearableIds and [...,444,444,...] for depositIds )
3. The transaction will revert because the previous code was only looking for tokenId, but now the code needs to see when delegation changes (nonce or grantor) 

With that fix, now the `equipWearables` function will check not only if it has two gloves with the same id, but also if it has the same deposit id (grantor and nonce).